### PR TITLE
Fix handling of docker images

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -71,7 +71,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi-platform
-        run: docker buildx build . --push --file Dockerfile --platform 'linux/amd64' --pull --provenance false --build-arg TAG="${{needs.select-tag.outputs.build-tag}}" -t "ghcr.io/$GITHUB_REPOSITORY:${{needs.select-tag.outputs.build-tag}}"
+        run: docker buildx build . --push --file Dockerfile --platform 'linux/amd64,linux/386' --pull --provenance false --build-arg TAG="${{needs.select-tag.outputs.build-tag}}" -t "ghcr.io/$GITHUB_REPOSITORY:${{needs.select-tag.outputs.build-tag}}"
         
       - name: Make bin directory
         run: mkdir /tmp/fb-bins

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -84,13 +84,12 @@ jobs:
             docker pull "$tag@$digest"
             bash extract-fb-bin.sh "$tag@$digest"
           done
-          md5sum fluent* > MD5SUMS
-          sha1sum fluent* > SHA1SUMS
-          sha256sum fluent* > SHA256SUMS
-        working-directory: /tmp/fb-bins
       
       - name: Prepare release body
         run: |
+           md5sum fluent* > MD5SUMS
+           sha1sum fluent* > SHA1SUMS
+           sha256sum fluent* > SHA256SUMS
            curl -s "https://api.github.com/repos/fluent/fluent-bit/releases" | jq -r '.[] | select(.tag_name == "${{needs.select-tag.outputs.build-tag}}") | .body' > /tmp/body.md
            echo "" >> /tmp/body.md
            echo "Binary SHA1 sums:" >> /tmp/body.md

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -71,7 +71,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi-platform
-        run: docker buildx build . --push --file Dockerfile --platform 'linux/amd64,linux/386' --pull --provenance false --build-arg TAG="${{needs.select-tag.outputs.build-tag}}" -t "ghcr.io/$GITHUB_REPOSITORY:${{needs.select-tag.outputs.build-tag}}"
+        run: docker buildx build . --push --file Dockerfile --platform 'linux/amd64,linux/386,linux/arm64,linux/arm/v7' --pull --provenance false --build-arg TAG="${{needs.select-tag.outputs.build-tag}}" -t "ghcr.io/$GITHUB_REPOSITORY:${{needs.select-tag.outputs.build-tag}}"
         
       - name: Make bin directory
         run: mkdir /tmp/fb-bins

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -96,13 +96,12 @@ jobs:
            echo '```' >> /tmp/body.md
            cat SHA1SUMS >> /tmp/body.md
            echo '```' >> /tmp/body.md
-           cat /tmp/body.md
         working-directory: /tmp/fb-bins
 
-      # - name: Publish release
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     artifacts: "/tmp/fb-bins/*"
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     tag: ${{needs.select-tag.outputs.build-tag}}
-      #     bodyFile: /tmp/body.md
+      - name: Publish release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "/tmp/fb-bins/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{needs.select-tag.outputs.build-tag}}
+          bodyFile: /tmp/body.md

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -71,7 +71,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi-platform
-        run: docker buildx build . --push --file Dockerfile --platform 'linux/amd64,linux/386,linux/arm64,linux/arm/v7' --pull --provenance false --build-arg TAG="${{needs.select-tag.outputs.build-tag}}" -t "ghcr.io/$GITHUB_REPOSITORY:${{needs.select-tag.outputs.build-tag}}"
+        run: docker buildx build . --push --file Dockerfile --platform 'linux/amd64' --pull --provenance false --build-arg TAG="${{needs.select-tag.outputs.build-tag}}" -t "ghcr.io/$GITHUB_REPOSITORY:${{needs.select-tag.outputs.build-tag}}"
         
       - name: Make bin directory
         run: mkdir /tmp/fb-bins
@@ -82,7 +82,7 @@ jobs:
           for digest in $(docker manifest inspect "$tag" | jq -r '.manifests[].digest')
           do
             docker pull "$tag@$digest"
-            docker save "$tag@$digest" | tar -xOf - --wildcards "*.tar" | tar -xvf -
+            bash extract-fb-bin.sh "$tag@$digest"
           done
           md5sum fluent* > MD5SUMS
           sha1sum fluent* > SHA1SUMS
@@ -97,12 +97,13 @@ jobs:
            echo '```' >> /tmp/body.md
            cat SHA1SUMS >> /tmp/body.md
            echo '```' >> /tmp/body.md
+           cat /tmp/body.md
         working-directory: /tmp/fb-bins
 
-      - name: Publish release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "/tmp/fb-bins/*"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{needs.select-tag.outputs.build-tag}}
-          bodyFile: /tmp/body.md
+      # - name: Publish release
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     artifacts: "/tmp/fb-bins/*"
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     tag: ${{needs.select-tag.outputs.build-tag}}
+      #     bodyFile: /tmp/body.md

--- a/extract-fb-bin.sh
+++ b/extract-fb-bin.sh
@@ -11,7 +11,7 @@ OUTER_TAR="$1"
 TMP_DIR=$(mktemp -d)
 
 # Extract the docker image into the temporary directory
-docker save "$1" | tar -x -C "$TMP_DIR" -
+docker save "$1" | tar -x -C "$TMP_DIR" -f -
 
 # Find the inner tar file that contains a file starting with 'fluent-bit'
 INNER_TAR=""

--- a/extract-fb-bin.sh
+++ b/extract-fb-bin.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Check if the docker image
+if [ -z "$1" ]; then
+    echo "Usage: $0 <docker-image>"
+    exit 1
+fi
+
+# Define variables
+OUTER_TAR="$1"
+TMP_DIR=$(mktemp -d)
+
+# Extract the docker image into the temporary directory
+docker save "$tag@$digest" | tar -x -C "$TMP_DIR" -
+
+# Find the inner tar file that contains a file starting with 'fluent-bit'
+INNER_TAR=""
+while IFS= read -r -d '' file; do
+    if tar -tf "$file" &> /dev/null && tar -tf "$file" | grep -q '^fluent-bit'; then
+        INNER_TAR="$file"
+        break
+    fi
+done < <(find "$TMP_DIR" -type f -print0)
+
+# Check if the inner tar file was found
+if [ -z "$INNER_TAR" ]; then
+    echo "Inner tar file containing a file that starts with 'fluent-bit' not found."
+    exit 1
+fi
+
+# Extract the inner tar file to /tmp/fb-bins
+tar -xf "$INNER_TAR" -C /tmp/fb-bins
+
+# Output the location of the extracted files
+echo "Extracted inner tar file to: /tmp/fb-bins"
+
+# Optionally, clean up the temporary directory
+# Uncomment the next line if you want to remove the temporary directory after extraction
+rm -rf "$TMP_DIR"
+
+exit 0

--- a/extract-fb-bin.sh
+++ b/extract-fb-bin.sh
@@ -11,7 +11,7 @@ OUTER_TAR="$1"
 TMP_DIR=$(mktemp -d)
 
 # Extract the docker image into the temporary directory
-docker save "$tag@$digest" | tar -x -C "$TMP_DIR" -
+docker save "$1" | tar -x -C "$TMP_DIR" -
 
 # Find the inner tar file that contains a file starting with 'fluent-bit'
 INNER_TAR=""


### PR DESCRIPTION
The `docker save` output no longer contains files with `.tar` suffixes.  Add a script to scrape through the contents of the save to find the tarball with the fluent-bit image inside of it.