### PR TITLE
Use matrixed build

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -144,6 +144,7 @@ jobs:
           docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 --os linux --arch arm --variant v7
           docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64 --os linux --arch arm64
           # Push the multi-architecture image to the registry
+          echo "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
           docker manifest push "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
 
       - name: Merge binaries

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -89,13 +89,13 @@ jobs:
 
       - name: Export Docker image to file
         run: |
-          docker save "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}" -o "image_fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
+          docker save "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}" -o "fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4
         with:
           name: docker-image-${{ matrix.arch.name }}
-          path: "image_fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
+          path: "fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
 
       - name: Create bin directory
         run: mkdir -p /tmp/fb-bins
@@ -126,11 +126,31 @@ jobs:
         with:
           path: /tmp/artifacts
 
+      - name: Create and push multi-architecture Docker image
+        run: |
+          # Load Docker images from artifact tar files
+          for file in /tmp/artifacts/docker-image-*.tar; do
+            docker load -i "$file"
+          done
+          # Create a multi-arch image manifest
+          docker manifest create "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" \
+            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-i386 \
+            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-amd64 \
+            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 \
+            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64
+          # Annotate each image with its architecture details
+          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-i386 --os linux --arch 386
+          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-amd64 --os linux --arch amd64
+          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 --os linux --arch arm --variant v7
+          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64 --os linux --arch arm64
+          # Push the multi-architecture image to the registry
+          docker manifest push "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
+
       - name: Merge binaries
         run: |
           ls -alF /tmp/artifacts
           mkdir -p /tmp/fb-bins
-          cp /tmp/artifacts/fluent-bit* /tmp/fb-bins/
+          cp /tmp/artifacts/fb-bins-*/* /tmp/fb-bins/
           ls -alF /tmp/fb-bins
 
       - name: Prepare release body

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Build and push images
         run: |
-          docker buildx build . --file Dockerfile \
+          docker buildx build . --file Dockerfile --load \
             --platform '${{ matrix.arch.platform }}' --pull --provenance false \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
             -t "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Create and push multi-architecture Docker image
         run: |
           # Load Docker images from artifact tar files
-          for file in /tmp/artifacts/docker-image-*.tar; do
+          for file in /tmp/artifacts/docker-image-*/*.tar; do
             docker load -i "$file"
           done
           # Create a multi-arch image manifest

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build and push images
         run: |
           docker buildx build . --push --file Dockerfile \
-            --platform '${{ matrix.arch.platforms }}' --pull --provenance false \
+            --platform '${{ matrix.arch.platform }}' --pull --provenance false \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
             -t "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
 

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: select-tag
     outputs:
-      outcome: failure
+      outcome: ${{ steps.exists.outcome }}
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
@@ -145,4 +145,11 @@ jobs:
           echo '```' >> /tmp/body.md
           cat SHA1SUMS >> /tmp/body.md
           echo '```' >> /tmp/body.md
-          cat /tmp/body.md
+
+      - name: Publish release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "/tmp/fb-bins/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.select-tag.outputs.build-tag }}
+          bodyFile: /tmp/body.md

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -80,19 +80,22 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push images
         run: |
           docker buildx build . --file Dockerfile --load \
             --platform '${{ matrix.arch.platform }}' --pull --provenance false \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
             -t "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"
+
+      - name: Export Docker image to file
+        run: |
+          docker save "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}" -o "image_fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-${{ matrix.arch.name }}
+          path: "image_fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
 
       - name: Create bin directory
         run: mkdir -p /tmp/fb-bins
@@ -111,35 +114,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ select-tag, build ]
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download i386 binaries artifact
         uses: actions/download-artifact@v4
         with:
-          name: fb-bins-i386
-          path: /tmp/fb-bins-i386
-
-      - name: Download amd64 binaries artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: fb-bins-amd64
-          path: /tmp/fb-bins-amd64
-
-      - name: Download armv7 binaries artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: fb-bins-armv7
-          path: /tmp/fb-bins-armv7
-
-      - name: Download arm64 binaries artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: fb-bins-arm64
-          path: /tmp/fb-bins-arm64
+          path: /tmp/artifacts
 
       - name: Merge binaries
         run: |
-          ls -alF /tmp/fb-bins-*
+          ls -alF /tmp/artifacts
           mkdir -p /tmp/fb-bins
-          cp -a /tmp/fb-bins-*/. /tmp/fb-bins/
+          cp /tmp/artifacts/fluent-bit* /tmp/fb-bins/
           ls -alF /tmp/fb-bins
 
       - name: Prepare release body

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -139,10 +139,10 @@ jobs:
             fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 \
             fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64
           # Annotate each image with its architecture details
-          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-i386 --os linux --arch 386
-          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-amd64 --os linux --arch amd64
-          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 --os linux --arch arm --variant v7
-          docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64 --os linux --arch arm64
+          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-i386 --os linux --arch 386
+          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-amd64 --os linux --arch amd64
+          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 --os linux --arch arm --variant v7
+          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64 --os linux --arch arm64
           # Push the multi-architecture image to the registry
           echo "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
           docker manifest push "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -60,19 +60,15 @@ jobs:
           - name: i386
             runs_on: ubuntu-24.04
             platform: "linux/386"
-            artifact: fb-bins-i386
           - name: amd64
             runs_on: ubuntu-24.04
             platform: "linux/amd64"
-            artifact: fb-bins-amd64
           - name: armv7
             runs_on: ubuntu-24.04-arm
             platform: "linux/arm/v7"
-            artifact: fb-bins-armv7
           - name: arm64
             runs_on: ubuntu-24.04-arm
             platform: "linux/arm64"
-            artifact: fb-bins-arm64
     steps:
       - uses: actions/checkout@v3
 
@@ -80,35 +76,18 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push images
         run: |
-          docker buildx build . --file Dockerfile --load \
-            --platform '${{ matrix.arch.platform }}' --pull --provenance false \
+          docker buildx build . --file Dockerfile --platform '${{ matrix.arch.platform }}' --pull \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
-            -t "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"
-
-      - name: Export Docker image to file
-        run: |
-          docker save "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}" -o "fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
-
-      - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-image-${{ matrix.arch.name }}
-          path: "fluent-bit-static_${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}.tar"
-
-      - name: Create bin directory
-        run: mkdir -p /tmp/fb-bins
-
-      - name: Extract binaries
-        run: |
-          bash extract-fb-bin.sh "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"
-
-      - name: Upload binaries artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.arch.artifact }}
-          path: /tmp/fb-bins
+            -t "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}" --push
 
   publish-release:
     runs-on: ubuntu-latest
@@ -121,38 +100,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download i386 binaries artifact
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/artifacts
-
       - name: Create and push multi-architecture Docker image
         run: |
-          # Load Docker images from artifact tar files
-          for file in /tmp/artifacts/docker-image-*/*.tar; do
-            docker load -i "$file"
-          done
-          # Create a multi-arch image manifest
-          docker manifest create "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" \
-            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-i386 \
-            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-amd64 \
-            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 \
-            fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64
-          # Annotate each image with its architecture details
-          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-i386 --os linux --arch 386
-          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-amd64 --os linux --arch amd64
-          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-armv7 --os linux --arch arm --variant v7
-          # docker manifest annotate "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}" fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-arm64 --os linux --arch arm64
-          # Push the multi-architecture image to the registry
-          echo "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
-          docker manifest push "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
+          docker manifest create "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}" \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-i386 \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-amd64 \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-armv7 \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-arm64
+          docker manifest annotate "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}" \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-i386 --os linux --arch 386
+          docker manifest annotate "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}" \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-amd64 --os linux --arch amd64
+          docker manifest annotate "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}" \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-armv7 --os linux --arch arm --variant v7
+          docker manifest annotate "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}" \
+            ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-arm64 --os linux --arch arm64
+          docker manifest push "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}"
 
-      - name: Merge binaries
+      - name: Extract binaries
         run: |
-          ls -alF /tmp/artifacts
-          mkdir -p /tmp/fb-bins
-          cp /tmp/artifacts/fb-bins-*/* /tmp/fb-bins/
-          ls -alF /tmp/fb-bins
+          tag="ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}"
+          for digest in $(docker manifest inspect "$tag" | jq -r '.manifests[].digest'); do
+            docker pull "$tag@$digest"
+            bash extract-fb-bin.sh "$tag@$digest"
+          done
 
       - name: Prepare release body
         run: |

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -120,6 +120,9 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-arm64 --os linux --arch arm64
           docker manifest push "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}"
 
+      - name: Create bin directory
+        run: mkdir -p /tmp/fb-bins
+
       - name: Extract binaries
         run: |
           tag="ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}"

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -89,21 +89,17 @@ jobs:
 
       - name: Build and push images
         run: |
-          docker buildx build . --push --file Dockerfile \
+          docker buildx build . --file Dockerfile \
             --platform '${{ matrix.arch.platform }}' --pull --provenance false \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
-            -t "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
+            -t "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"
 
       - name: Create bin directory
         run: mkdir -p /tmp/fb-bins
 
       - name: Extract binaries
         run: |
-          tag="ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
-          for digest in $(docker manifest inspect "$tag" | jq -r '.manifests[].digest'); do
-            docker pull "$tag@$digest"
-            bash extract-fb-bin.sh "$tag@$digest"
-          done
+          bash extract-fb-bin.sh "fluent-bit-static:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"
 
       - name: Upload binaries artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -57,14 +57,22 @@ jobs:
     strategy:
       matrix:
         arch:
-          - name: x86
+          - name: i386
             runs_on: ubuntu-24.04
-            platforms: "linux/amd64,linux/386"
-            artifact: fb-bins-x86
-          - name: arm
+            platform: "linux/386"
+            artifact: fb-bins-i386
+          - name: amd64
+            runs_on: ubuntu-24.04
+            platform: "linux/amd64"
+            artifact: fb-bins-amd64
+          - name: armv7
             runs_on: ubuntu-24.04-arm
-            platforms: "linux/arm64,linux/arm/v7"
-            artifact: fb-bins-arm
+            platform: "linux/arm/v7"
+            artifact: fb-bins-armv7
+          - name: arm64
+            runs_on: ubuntu-24.04-arm
+            platform: "linux/arm64"
+            artifact: fb-bins-arm64
     steps:
       - uses: actions/checkout@v3
 
@@ -107,25 +115,35 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ select-tag, build ]
     steps:
-      - name: Download x86 binaries artifact
+      - name: Download i386 binaries artifact
         uses: actions/download-artifact@v4
         with:
-          name: fb-bins-x86
-          path: /tmp/fb-bins-x86
+          name: fb-bins-i386
+          path: /tmp/fb-bins-i386
 
-      - name: Download ARM binaries artifact
+      - name: Download amd64 binaries artifact
         uses: actions/download-artifact@v4
         with:
-          name: fb-bins-arm
-          path: /tmp/fb-bins-arm
+          name: fb-bins-amd64
+          path: /tmp/fb-bins-amd64
+
+      - name: Download armv7 binaries artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: fb-bins-armv7
+          path: /tmp/fb-bins-armv7
+
+      - name: Download arm64 binaries artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: fb-bins-arm64
+          path: /tmp/fb-bins-arm64
 
       - name: Merge binaries
         run: |
-          ls -alF /tmp/fb-bins-x86
-          ls -alF /tmp/fb-bins-arm
+          ls -alF /tmp/fb-bins-*
           mkdir -p /tmp/fb-bins
-          cp -a /tmp/fb-bins-x86/. /tmp/fb-bins/
-          cp -a /tmp/fb-bins-arm/. /tmp/fb-bins/
+          cp -a /tmp/fb-bins-*/. /tmp/fb-bins/
           ls -alF /tmp/fb-bins
 
       - name: Prepare release body

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -86,9 +86,9 @@ jobs:
       - name: Build and push images
         run: |
           docker buildx build . --push --file Dockerfile \
-            --platform '${{ matrix.arch.platforms }}' --pull --provenance false \
+            --platform '${{ matrix.arch.platform }}' --pull --provenance false \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
-            -t "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"
+            -t "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}" --push
 
   publish-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: select-tag
     outputs:
-      outcome: ${{ steps.exists.outcome }}
+      outcome: failure
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -134,7 +134,6 @@ jobs:
           path: /tmp/fb-bins
 
   publish-release:
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: [ select-tag, build-x86, build-arm ]
     steps:
@@ -152,9 +151,12 @@ jobs:
 
       - name: Merge binaries
         run: |
+          ls -alF /tmp/fb-bins-x86
+          ls -alF /tmp/fb-bins-arm
           mkdir -p /tmp/fb-bins
           cp -a /tmp/fb-bins-x86/. /tmp/fb-bins/
           cp -a /tmp/fb-bins-arm/. /tmp/fb-bins/
+          ls -alF /tmp/fb-bins
 
       - name: Prepare release body
         run: |
@@ -170,11 +172,4 @@ jobs:
           echo '```' >> /tmp/body.md
           cat SHA1SUMS >> /tmp/body.md
           echo '```' >> /tmp/body.md
-
-      - name: Publish release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "/tmp/fb-bins/*"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.select-tag.outputs.build-tag }}
-          bodyFile: /tmp/body.md
+          cat /tmp/body.md

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -94,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ select-tag, build ]
     steps:
+      - uses: actions/checkout@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -85,9 +85,10 @@ jobs:
 
       - name: Build and push images
         run: |
-          docker buildx build . --file Dockerfile --platform '${{ matrix.arch.platform }}' --pull \
+          docker buildx build . --push --file Dockerfile \
+            --platform '${{ matrix.arch.platforms }}' --pull --provenance false \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
-            -t "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}" --push
+            -t "ghcr.io/${{ github.repository }}:${{ needs.select-tag.outputs.build-tag }}-${{ matrix.arch.name }}"
 
   publish-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -49,10 +49,22 @@ jobs:
         with:
           tag: ${{ needs.select-tag.outputs.build-tag }}
 
-  build-x86:
-    runs-on: ubuntu-24.04
+  build:
+    name: Build ${{ matrix.arch.name }} images
+    runs-on: ${{ matrix.arch.runs_on }}
     needs: [ select-tag, check-release ]
     if: ${{ needs.check-release.outputs.outcome == 'failure' }}
+    strategy:
+      matrix:
+        arch:
+          - name: x86
+            runs_on: ubuntu-24.04
+            platforms: "linux/amd64,linux/386"
+            artifact: fb-bins-x86
+          - name: arm
+            runs_on: ubuntu-24.04-arm
+            platforms: "linux/arm64,linux/arm/v7"
+            artifact: fb-bins-arm
     steps:
       - uses: actions/checkout@v3
 
@@ -70,7 +82,7 @@ jobs:
       - name: Build and push images
         run: |
           docker buildx build . --push --file Dockerfile \
-            --platform 'linux/amd64,linux/386' --pull --provenance false \
+            --platform '${{ matrix.arch.platforms }}' --pull --provenance false \
             --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
             -t "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
 
@@ -85,57 +97,15 @@ jobs:
             bash extract-fb-bin.sh "$tag@$digest"
           done
 
-      - name: Upload x86 binaries artifact
+      - name: Upload binaries artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fb-bins-x86
-          path: /tmp/fb-bins
-
-  build-arm:
-    runs-on: ubuntu-24.04-arm
-    needs: [ select-tag, check-release ]
-    if: ${{ needs.check-release.outputs.outcome == 'failure' }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push ARM images
-        run: |
-          docker buildx build . --push --file Dockerfile \
-            --platform 'linux/arm64,linux/arm/v7' --pull --provenance false \
-            --build-arg TAG="${{ needs.select-tag.outputs.build-tag }}" \
-            -t "ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
-
-      - name: Create bin directory
-        run: mkdir -p /tmp/fb-bins
-
-      - name: Extract binaries
-        run: |
-          tag="ghcr.io/$GITHUB_REPOSITORY:${{ needs.select-tag.outputs.build-tag }}"
-          for digest in $(docker manifest inspect "$tag" | jq -r '.manifests[].digest'); do
-            docker pull "$tag@$digest"
-            bash extract-fb-bin.sh "$tag@$digest"
-          done
-
-      - name: Upload ARM binaries artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: fb-bins-arm
+          name: ${{ matrix.arch.artifact }}
           path: /tmp/fb-bins
 
   publish-release:
     runs-on: ubuntu-latest
-    needs: [ select-tag, build-x86, build-arm ]
+    needs: [ select-tag, build ]
     steps:
       - name: Download x86 binaries artifact
         uses: actions/download-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,7 @@
-FROM debian:bookworm as build
-ARG TAG
-ARG TARGETARCH
-RUN test -n "$TAG" || (echo "TAG not set" && false)
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y build-essential cmake flex bison curl libyaml-dev libssl-dev
-
-RUN mkdir /tmp/build && chown nobody:nogroup /tmp/build
-
-USER nobody
-WORKDIR /tmp/build
-
-RUN curl -L "https://api.github.com/repos/fluent/fluent-bit/tarball/$TAG" | tar -xzf -
-
-RUN cd fluent*/build && \
-    cmake -DFLB_WASM=No -DFLB_LUAJIT=No -DFLB_DEBUG=No -DFLB_RELEASE=Yes -DFLB_SHARED_LIB=No -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" -DBUILD_SHARED_LIBS=OFF -DCMAKE_EXE_LINKER_FLAGS="-static" -DOPENSSL_USE_STATIC_LIBS=Yes -DCMAKE_C_FLAGS="-fcommon" .. && \
-    make && \
-    strip bin/fluent-bit && \
-    cp bin/fluent-bit "/tmp/fluent-bit-${TAG}-${TARGETARCH}"
-
 FROM scratch
 ARG TAG
 ARG TARGETARCH
 
-COPY --from=build --chown=0:0 /tmp/fluent-bit-${TAG}-${TARGETARCH} /
+RUN echo "test" > /fluent-bit-${TAG}-${TARGETARCH}
 
 ENTRYPOINT [ "/fluent-bit-${TAG}-${TARGETARCH}" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,21 @@ ARG TAG
 ARG TARGETARCH
 RUN test -n "$TAG" || (echo "TAG not set" && false)
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y build-essential cmake flex bison curl libyaml-dev libssl-dev
+
+RUN mkdir /tmp/build && chown nobody:nogroup /tmp/build
+
 USER nobody
 WORKDIR /tmp/build
 
-RUN echo "test" > "/tmp/fluent-bit-${TAG}-${TARGETARCH}"
+RUN curl -L "https://api.github.com/repos/fluent/fluent-bit/tarball/$TAG" | tar -xzf -
+
+RUN cd fluent*/build && \
+    cmake -DFLB_WASM=No -DFLB_LUAJIT=No -DFLB_DEBUG=No -DFLB_RELEASE=Yes -DFLB_SHARED_LIB=No -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" -DBUILD_SHARED_LIBS=OFF -DCMAKE_EXE_LINKER_FLAGS="-static" -DOPENSSL_USE_STATIC_LIBS=Yes -DCMAKE_C_FLAGS="-fcommon" .. && \
+    make && \
+    strip bin/fluent-bit && \
+    cp bin/fluent-bit "/tmp/fluent-bit-${TAG}-${TARGETARCH}"
 
 FROM scratch
 ARG TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
+FROM debian:bookworm as build
+ARG TAG
+ARG TARGETARCH
+RUN test -n "$TAG" || (echo "TAG not set" && false)
+
+USER nobody
+WORKDIR /tmp/build
+
+RUN echo "test" > "/tmp/fluent-bit-${TAG}-${TARGETARCH}"
+
 FROM scratch
 ARG TAG
 ARG TARGETARCH
 
-RUN echo "test" > /fluent-bit-${TAG}-${TARGETARCH}
+COPY --from=build --chown=0:0 /tmp/fluent-bit-${TAG}-${TARGETARCH} /
 
 ENTRYPOINT [ "/fluent-bit-${TAG}-${TARGETARCH}" ]


### PR DESCRIPTION
Switch to using a matrixed build strategy.  This does necessitate tagging and pushing each architecture to GHCR and then creating the multi-arch docker image afterwards.  Hopefully the release works properly.